### PR TITLE
Add S₀ Tuning (PEFT for hybrid recurrent-attention models)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ LoRA is an efficient finetuning technique proposed by Microsoft researchers to a
 
 | Year | Title                                                        | **Venue** |                            Paper                             |                             Code                             |     **Keywords**     |
 | :--: | :----------------------------------------------------------- | :-------: | :----------------------------------------------------------: | :----------------------------------------------------------: | :-------: |
+| 2026 | **S₀ Tuning: Zero-Overhead Adaptation of Hybrid Recurrent-Attention Models** | arXiv | [Link](https://arxiv.org/abs/2604.01168) | [Link](https://github.com/JackYoung27/s0-tuning) | Recurrent State Optimization; Zero Inference Overhead; Hybrid Models |
 | 2025 | **DMLoRA: Dynamic Multi-Subspace Low-Rank Adaptation** | WWW | [Link](https://dl.acm.org/doi/abs/10.1145/3701716.3715489) | [Link](https://dl.acm.org/doi/abs/10.1145/3701716.3715489) | Dynamic Multi-Subspace;|
 | 2025 | **PointLoRA: Low-Rank Adaptation with Token Selection for Point Cloud Learning** | CVPR | [Link](https://arxiv.org/abs/2504.16023) | [Link](https://github.com/songw-zju/PointLoRA) | Point Cloud Learning; Token Selection;|
 | 2025 | **LoRMA: Low-Rank Multiplicative Adaptation for LLMs** | ACL Findings | [Link](https://arxiv.org/abs/2506.07621) | [Link](https://github.com/Exploration-Lab/LoRMA) | Multiplicative; Rank-Inflation; Faster Convergence;|
@@ -143,7 +144,3 @@ LoRA is an efficient finetuning technique proposed by Microsoft researchers to a
 
 ## Packages
 Huggingface PEFT [Link](https://github.com/huggingface/peft) 
-
-
-
-


### PR DESCRIPTION
S₀ tuning optimizes one state matrix per recurrent layer while freezing all model weights. On Qwen3.5-4B: +23.6 pp on HumanEval (p < 0.001, 10 seeds), +10.8 pp over LoRA, zero inference overhead. Tested on FalconH1-7B (Mamba-2).

Paper: https://arxiv.org/abs/2604.01168
Code: https://github.com/JackYoung27/s0-tuning